### PR TITLE
docs: fix type in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,7 +604,7 @@ function stages that we've been discussing:
                      (reduce (fn [a f] [(apply f a)])
                      args (:in d)))
         envb (apply-env-fns enva :tf)
-        res (if-not ((:op envb))
+        res (if-not (:op envb)
                 (:args envb)
                 (apply (:op envb) (:args envb)))
         envc (assoc d :res (reduce (fn [r f] (f r))


### PR DESCRIPTION
Problem:
```
Execution error (ArityException) at io.erical.scratches.scratch11/abstract-function (scratch11.clj:15).
Wrong number of args (0) passed to: io.erical.scratches.scratch11/fahrenheit
```

Solution:
```clj
(ns io.erical.scratches.scratch11)

(def data {:args [] :in [] :tf [] :op nil :out [] :tf-end [] :res nil})

(defn apply-env-fns [env k]
  (if-not (seq (get env k))
    env
    (reduce (fn [e f] (f e)) env (get env k))))

(defn abstract-function [d & args]
  (let [enva (update d :args into
               (reduce (fn [a f] [(apply f a)])
                 args (:in d)))
        envb (apply-env-fns enva :tf)
        res (if-not (:op envb)
              (:args envb)
              (apply (:op envb) (:args envb)))
        envc (assoc d :res (reduce (fn [r f] (f r))
                             res (:out envb)))
        envd (apply-env-fns envc :tf-end)]
    (:res envd)))

(abstract-function
  (-> data (assoc :op +))
  1 2 3)

(defn fahrenheit [c]
  (* (/ 5 9) (- c 32)))

(abstract-function
  (-> data (assoc :op fahrenheit)) ;=> 40
  104)
```